### PR TITLE
change default value to a placeholder

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,12 +25,12 @@
 				<div id="target" class="place-inputs">
 					<div class="place-input">
 						<label>
-							From: <input id="from" type="text" value="Nob Hill, San Francisco, CA">
+							From: <input id="from" type="text" placeholder="Nob Hill, San Francisco, CA">
 						</label>
 					</div>
 					<div class="place-input">
 						<label>
-							To: <input id="to" type="text" value="Russian Hill, San Francisco, CA">
+							To: <input id="to" type="text" placeholder="Russian Hill, San Francisco, CA">
 						</label>
 					</div>
 				</div>


### PR DESCRIPTION
sometimes, especially on mobile, it's annoying to remove the text in the box. it would be easier to just tap there and enter what you want.

this is supported in all except IE < 10. http://www.w3schools.com/tags/att_input_placeholder.asp

I can see the case for entering two locations to give a demo of the app, but in that case it should actually get the user directions (to show them the rest of the demo). No directions, no defaults. that's my 2c.

I think this also matches the expected look for fields where the user should enter stuff. Right now it doesn't look actionable because it's already filled in.
